### PR TITLE
Add flutter-wordpress-podcast app

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ Hooks are a new kind of object that manage the life-cycle of a Widget. They exis
 
 - ![](https://img.shields.io/github/stars/Blakexx/CryptoTracker?style=social) [Platypus Crypto](https://github.com/Blakexx/CryptoTracker): Platypus Crypto is an ad-free cross-platform robust solution for tracking cryptocurrency assets. Our intuitive interface includes real-time 7-day graphs, current prices and market caps, and percent change over time. Featuring rapid sort, search and refresh features, and support for 32 fiat currencies, Platypus Crypto enables casual and power users alike to monitor cryptocurrency assets on-the-go! Our customization options allow for the removal of 7-day graphs for a more compact feel and a dark theme.
 
-- ![](https://img.shields.io/github/stars/PierreBresson/flutter-wordpress-podcast?style=social)  [Flutter Wordpress Podcast](https://github.com/PierreBresson/flutter-wordpress-podcast):  Podcast white label app based on Wordpress API
+- ![](https://img.shields.io/github/stars/PierreBresson/flutter-wordpress-podcast?style=social)  [Flutter Wordpress Podcast](https://github.com/PierreBresson/flutter-wordpress-podcast): 🎤 Podcast white label app based on Wordpress API
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -583,6 +583,8 @@ Hooks are a new kind of object that manage the life-cycle of a Widget. They exis
 
 - ![](https://img.shields.io/github/stars/Blakexx/CryptoTracker?style=social) [Platypus Crypto](https://github.com/Blakexx/CryptoTracker): Platypus Crypto is an ad-free cross-platform robust solution for tracking cryptocurrency assets. Our intuitive interface includes real-time 7-day graphs, current prices and market caps, and percent change over time. Featuring rapid sort, search and refresh features, and support for 32 fiat currencies, Platypus Crypto enables casual and power users alike to monitor cryptocurrency assets on-the-go! Our customization options allow for the removal of 7-day graphs for a more compact feel and a dark theme.
 
+- ![](https://img.shields.io/github/stars/PierreBresson/flutter-wordpress-podcast?style=social)  [Flutter Wordpress Podcast](https://github.com/PierreBresson/flutter-wordpress-podcast):  Podcast white label app based on Wordpress API
+
 ## Contribution
 
 Your contributions and suggestions are heartily welcome.


### PR DESCRIPTION
Adding [flutter-wordpress-podcast](https://github.com/PierreBresson/flutter-wordpress-podcast) to the list. It's a white label app based on flutter with more than 10 000+ [installs](https://play.google.com/store/apps/details?id=com.thinkerview) on android.