### PR TITLE
Added link of Flutter Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ A curated list of awesome Flutter libraries, tools, tutorials, articles and more
 - ![](https://img.shields.io/github/stars/olexale/flutter_roadmap?style=social) [Flutter Roadmap](https://github.com/olexale/flutter_roadmap)
 - ![](https://img.shields.io/github/stars/mkobuolys/flutter-design-patterns?style=social) [flutter-design-patterns](https://github.com/mkobuolys/flutter-design-patterns) - An open-source design patterns application built with Dart and Flutter.
 - ![](https://img.shields.io/github/stars/VB10/flutter-architecture-template?style=social) [flutter-architecture-template](https://github.com/VB10/flutter-architecture-template) - This project craeeted for proffesionel application arhitecture.
+- ![](https://github.com/kamranahmedse/developer-roadmap) [Flutter Developer Roadmap](https://github.com/kamranahmedse/developer-roadmap)
 
 **Best Practices**:
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ A curated list of awesome Flutter libraries, tools, tutorials, articles and more
 - ![](https://img.shields.io/github/stars/olexale/flutter_roadmap?style=social) [Flutter Roadmap](https://github.com/olexale/flutter_roadmap)
 - ![](https://img.shields.io/github/stars/mkobuolys/flutter-design-patterns?style=social) [flutter-design-patterns](https://github.com/mkobuolys/flutter-design-patterns) - An open-source design patterns application built with Dart and Flutter.
 - ![](https://img.shields.io/github/stars/VB10/flutter-architecture-template?style=social) [flutter-architecture-template](https://github.com/VB10/flutter-architecture-template) - This project craeeted for proffesionel application arhitecture.
-- ![](https://img.shields.io/github/stars/kamranahmedse/developer-roadmap) [Flutter Developer Roadmap](https://github.com/kamranahmedse/developer-roadmap)
+- ![](https://img.shields.io/github/stars/kamranahmedse/developer-roadmap?style=social) [Flutter Developer Roadmap](https://github.com/kamranahmedse/developer-roadmap)
 
 **Best Practices**:
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ A curated list of awesome Flutter libraries, tools, tutorials, articles and more
 - ![](https://img.shields.io/github/stars/olexale/flutter_roadmap?style=social) [Flutter Roadmap](https://github.com/olexale/flutter_roadmap)
 - ![](https://img.shields.io/github/stars/mkobuolys/flutter-design-patterns?style=social) [flutter-design-patterns](https://github.com/mkobuolys/flutter-design-patterns) - An open-source design patterns application built with Dart and Flutter.
 - ![](https://img.shields.io/github/stars/VB10/flutter-architecture-template?style=social) [flutter-architecture-template](https://github.com/VB10/flutter-architecture-template) - This project craeeted for proffesionel application arhitecture.
-- ![](https://github.com/kamranahmedse/developer-roadmap) [Flutter Developer Roadmap](https://github.com/kamranahmedse/developer-roadmap)
+- ![](https://img.shields.io/github/stars/kamranahmedse/developer-roadmap) [Flutter Developer Roadmap](https://github.com/kamranahmedse/developer-roadmap)
 
 **Best Practices**:
 


### PR DESCRIPTION
Hi @nepaul,

I came across your repository [awesome-flutter](https://github.com/nepaul/awesome-flutter) and found it to be a valuable resource for Flutter enthusiasts.

While browsing through the repository, I noticed that it was missing link to a structured guide such as the famous ["Flutter Developer Roadmap"](https://roadmap.sh/flutter) which is the 6th most starred project of GitHub . I took the initiative to submit a ["Pull Request"](https://github.com/nepaul/awesome-flutter/pull/6) adding it in Document section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz